### PR TITLE
feature/rx-dart-migration

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,8 @@
 name: stateful_view_model
 description: A starting point for Dart libraries or applications.
 version: 0.1.0
-homepage: https://github.com/tikkrapp/stateful_view_model
-author: Tikkr <info@tikkr.app>
+homepage: https://github.com/tappeddev/stateful_view_model
+author: Tapped <contact@tapped.dev>
 
 environment:
   sdk: '>=2.0.0 <3.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   meta: ^1.1.6
-  rxdart: ^0.22.1+1
+  rxdart: ^0.23.1
 
 dev_dependencies:
   pedantic: ^1.7.0


### PR DESCRIPTION
Only merge when all projects are migrated to a new version of rx dart.
You can use this branch during the migration process.